### PR TITLE
Registro 0500 e 0600 do Sped-Contribuições

### DIFF
--- a/SpedBr/SpedBr.EfdContribuicoes/Bloco0.cs
+++ b/SpedBr/SpedBr.EfdContribuicoes/Bloco0.cs
@@ -399,6 +399,106 @@ namespace SpedBr.EfdContribuicoes
             public string DescrNat { get; set; }
         }
 
+        /// <summary>
+        ///     REGISTRO 0500: PLANO DE CONTAS CONTÁBEIS
+        /// </summary>
+        public class Registro0500 : RegistroBaseSped
+        {
+            /// <summary>
+            ///     Inicializa uma nova instância da classe <see cref="Registro0500" />.
+            /// </summary>
+            public Registro0500()
+            {
+                Reg = "0500";
+            }
+
+            /// <summary>
+            ///     Data de inclusão/alteração
+            /// </summary>
+            [SpedCampos(2, "DT_ALT", "N", 8, 0, true)]
+            public DateTime DtAlt { get; set; }
+
+            /// <summary>
+            ///     Código da natureza da conta/grupo de contas:
+            ///     01 - Contas de ativo;
+            ///     02 - Contas de passivo;
+            ///     03 - Patrimônio líquido;
+            ///     04 - Contas de resultado;
+            ///     05 - Contas de compensação;
+            ///     09 - Outras.
+            /// </summary>
+            [SpedCampos(3, "COD_NAT_CC", "C", 2, 0, true)]
+            public int CodNatCc { get; set; }
+
+            /// <summary>
+            ///     Indicador do tipo de conta: S - Sintética (grupo de contas); A - Analítica (conta).
+            /// </summary>
+            [SpedCampos(4, "IND_CTA", "C", 1, 0, true)]
+            public string IndCta { get; set; }
+
+            /// <summary>
+            ///     Nível da conta analítica/grupo de contas.
+            /// </summary>
+            [SpedCampos(5, "NIVEL", "N", 5, 0, true)]
+            public int Nivel { get; set; }
+
+            /// <summary>
+            ///     Código da conta analítica/grupo de contas.
+            /// </summary>
+            [SpedCampos(6, "COD_CTA", "C", 255, 0, true)]
+            public string CodCta { get; set; }
+
+            /// <summary>
+            ///     Nome da conta analítica/grupo de contas.
+            /// </summary>
+            [SpedCampos(7, "NOME_CTA", "C", 60, 0, true)]
+            public string NomeCta { get; set; }
+
+            /// <summary>
+            ///     Codigo da conta correlacionada no Plano de Contas Referenciado, publicado pela RFB.
+            /// </summary>
+            [SpedCampos(8, "COD_CTA_REF", "C", 60, 0, false)]
+            public string CodCtaRef { get; set; }
+
+            /// <summary>
+            ///     CNPJ do estabelecimento, no caso da conta informada no campo COD_CTA ser específica de um estabelecimento.
+            /// </summary>
+            [SpedCampos(9, "CNPJ_EST", "N", 14, 0, false)]
+            public string CnpjEst { get; set; }
+        }
+
+        /// <summary>
+        ///     REGISTRO 0600: CENTRO DE CUSTOS
+        /// </summary>
+        public class Registro0600 : RegistroBaseSped
+        {
+            /// <summary>
+            ///     Inicializa uma nova instância da classe <see cref="Registro0600" />.
+            /// </summary>
+            public Registro0600()
+            {
+                Reg = "0600";
+            }
+
+            /// <summary>
+            ///     Data da inclusão/alteração
+            /// </summary>
+            [SpedCampos(2, "DT_ALT", "N", 8, 0, true)]
+            public DateTime DtAlt { get; set; }
+
+            /// <summary>
+            ///     Código do centro de custos.
+            /// </summary>
+            [SpedCampos(3, "COD_CCUS", "C", 255, 0, true)]
+            public string CodCcus { get; set; }
+
+            /// <summary>
+            ///     Nome do centro de custos.
+            /// </summary>
+            [SpedCampos(4, "CCUS", "C", 60, 0, true)]
+            public string Ccus { get; set; }
+        }
+
         public class Registro0990 : RegistroBaseSped
         {
             public Registro0990()

--- a/SpedBr/SpedBr.EfdContribuicoes/Bloco0.cs
+++ b/SpedBr/SpedBr.EfdContribuicoes/Bloco0.cs
@@ -144,7 +144,7 @@ namespace SpedBr.EfdContribuicoes
             public int CodTipoCont { get; set; }
 
             [SpedCampos(5, "IND_REG_CUM", "N", 1, 0, false)]
-            public int IndRegCum { get; set; }
+            public int? IndRegCum { get; set; }
         }
 
         public class Registro0140 : RegistroBaseSped
@@ -395,7 +395,7 @@ namespace SpedBr.EfdContribuicoes
             /// <summary>
             ///     Descrição da natureza da operação/prestação
             /// </summary>
-            [SpedCampos(3, "DESCR_NAT", "C", 200, 0, true)]
+            [SpedCampos(3, "DESCR_NAT", "C", 250, 0, true)]
             public string DescrNat { get; set; }
         }
 

--- a/SpedBr/SpedBr.EfdContribuicoes/BlocoM.cs
+++ b/SpedBr/SpedBr.EfdContribuicoes/BlocoM.cs
@@ -398,7 +398,7 @@ namespace SpedBr.EfdContribuicoes
             ///     sem contribuição apurada a pagar, conforme a Tabela 4.3.3.
             /// </summary>
             [SpedCampos(2, "CST_PIS", "C", 2, 0, true)]
-            public int CstPis { get; set; }
+            public string CstPis { get; set; }
 
             /// <summary>
             ///     Valor total da receita bruta no período. 
@@ -484,6 +484,206 @@ namespace SpedBr.EfdContribuicoes
             public string DescCompl { get; set; }
         }
 
+        /// <summary>
+        ///     REGISTRO M500: CRÉDITO DE COFINS RELATIVO AO PERIODO
+        /// </summary>
+        public class RegistroM500 : RegistroBaseSped
+        {
+            /// <summary>
+            ///     Inicializa uma nova instância da classe <see cref="RegistroM500"/>
+            /// </summary>
+            public RegistroM500()
+            {
+                Reg = "M500";
+            }
+
+            /// <summary>
+            ///     Código de Tipo de C´redito apurado no período, conforme a Tabela 4.3.6
+            /// </summary>
+            [SpedCampos(2, "COD_CRED", "C", 3, 0, true)]
+            public string CodCred { get; set; }
+
+            /// <summary>
+            ///     Indicador de Crédito Oriundo de:
+            ///     0- Operações próprias
+            ///     1- Evento de incorporação, cisão ou fusão
+            /// </summary>
+            [SpedCampos(3, "IND_CRED_ORI", "N", 1, 0, true)]
+            public int IndCredOri { get; set; }
+
+            /// <summary>
+            ///     Valor da base de Cálculo do Crédito
+            /// </summary>
+            [SpedCampos(4, "VL_BC_COFINS", "N", 0, 2, false)]
+            public decimal? VlBcCofins { get; set; }
+
+            /// <summary>
+            ///     Alíquota do COFINS (em percentual)
+            /// </summary>
+            [SpedCampos(5, "ALIQ_COFINS", "N", 8, 4, false)]
+            public decimal? AliqCofins { get; set; }
+
+            /// <summary>
+            ///     Quantidade - Base de cálculo do COFINS
+            /// </summary>
+            [SpedCampos(6, "QUANT_BC_COFINS", "N", 0, 3, false)]
+            public decimal? QuantBcCofins { get; set; }
+
+            /// <summary>
+            ///     Alíquota do Cofins (em reais)
+            /// </summary>
+            [SpedCampos(7, "ALI_COFINS_QUANT", "N", 0, 4, false)]
+            public decimal? AliqCofinsQuant { get; set; }
+
+            /// <summary>
+            ///     Valor total do crédito apurado no período
+            /// </summary>
+            [SpedCampos(8, "VL_CRED", "N", 0, 2, true)]
+            public decimal VlCred { get; set; }
+
+            /// <summary>
+            ///     Valor total dos ajustes de acréscimo
+            /// </summary>
+            [SpedCampos(9, "VL_AJUS_ACRES", "N", 0, 2, true)]
+            public decimal VlAjusAcres { get; set; }
+
+            /// <summary>
+            ///     Valor total dos ajustes de redução
+            /// </summary>
+            [SpedCampos(10, "VL_AJUS_REDUC", "N", 0, 2, true)]
+            public decimal VlAjusReduc { get; set; }
+
+            /// <summary>
+            ///     Valor total do crédito diferido no período
+            /// </summary>
+            [SpedCampos(11, "VL_CRED_DIF", "N", 0, 2, true)]
+            public decimal VlCredDif { get; set; }
+
+            /// <summary>
+            ///     Valor Total do Crédito Disponível relativo ao Período (08 + 09 – 10 – 11)
+            /// </summary>
+            [SpedCampos(12, "VL_CRED_DISP", "N", 0, 2, true)]
+            public decimal VlCredDisp { get; set; }
+
+            /// <summary>
+            ///     Indicador de opção de utilização do crédito disponível no período: 
+            ///     0 – Utilização do valor total para desconto da 
+            ///     contribuição apurada no período, no Registro M200; 
+            ///     1 – Utilização de valor parcial para desconto da 
+            ///     contribuição apurada no período, no Registro M200. 
+            /// </summary>
+            [SpedCampos(13, "IND_DESC_CRED", "C", 1, 0, true)]
+            public int IndDescCred { get; set; }
+
+            /// <summary>
+            ///     Valor do Crédito disponível, descontado  da contribuição
+            ///     apurada no próprio período.
+            ///     Se IND_DESC_CRED=0, informar o valor total do Campo 12;
+            ///     Se IND_DESC_CRED=1, informar o valor parcial do Campo 12
+            /// </summary>
+            [SpedCampos(14, "VL_CRED_DESC", "N", 0, 2, false)]
+            public decimal? VlCredDesc { get; set; }
+
+            /// <summary>
+            ///     Saldo de créditos a utilizar em períodos futuros (12 – 14)
+            /// </summary>
+            [SpedCampos(15, "VL_CRED_DESC", "N", 0, 2, true)]
+            public decimal SldCred { get; set; }
+        }
+        /// <summary>
+        ///     REGISTRO M505: DETALHAMENTO DA BASE DE CALCULO DO CRÉDITO APURADO NO PERÍODO – COFINS
+        /// </summary>
+        public class RegistroM505 : RegistroBaseSped
+        {
+            /// <summary>
+            ///     Inicializa uma nova instância da classe <see cref="RegistroM505"/>.
+            /// </summary>
+            public RegistroM505()
+            {
+                Reg = "M505";
+            }
+
+            /// <summary>
+            ///     Código da Base de Cálculo do Crédito apurado no período, conforme a Tabela 4.3.7. 
+            /// </summary>
+            [SpedCampos(2, "NAT_BC_CRED", "C", 2, 0, true)]
+            public string NatBcCred { get; set; }
+
+            /// <summary>
+            ///     Código da Situação Tributária referente ao crédito de COFINS (Tabela 4.3.3) 
+            ///     vinculado ao tipo de crédito escriturado em M100
+            /// </summary>
+            [SpedCampos(3, "CST_COFINS", "N", 2, 0, true)]
+            public int CstCofins { get; set; }
+
+            /// <summary>
+            ///     Valor Total da Base de Cálculo escriturada nos documentos e operações (Blocos "A", "C", "D", e "F"), 
+            ///     referente ao CST_COFINS informado no Campo 03.
+            /// </summary>
+            [SpedCampos(4, "VL_BC_COFINS_TOT", "N", 0, 2, false)]
+            public decimal? VlBcCofinsTot { get; set; }
+
+            /// <summary>
+            ///     Parcela do Valor Total da Base de Cálculo informada no Campo 04, 
+            ///     vinculada a receitas com incidência cumulativa. 
+            ///     Campo de preenchimento específico para a pessoa jurídica sujeita 
+            ///     ao regime cumulativo e não-cumulativo da contribuição 
+            ///     (COD_INC_TRIB = 3 do Registro 0110) 
+            /// </summary>
+            [SpedCampos(5, "VL_BC_COFINS_CUM", "N", 0, 2, false)]
+            public decimal? VlBcCofinsCum { get; set; }
+
+            /// <summary>
+            ///     Valor Total da Base de Cálculo do Crédito, 
+            ///     vinculada a receitas com incidência não-cumulativa (Campo 04 – Campo 05)
+            /// </summary>
+            [SpedCampos(6, "VL_BC_COFINS_NC", "N", 0, 2, false)]
+            public decimal? VlBcCofinsNc { get; set; }
+
+            /// <summary>
+            ///     Valor da Base de Cálculo do Crédito, vinculada ao tipo de Crédito escriturado em M500. 
+            ///     - Para os CST_COFINS = "50", "51", "52", "60", "61" e "62": Informar o valor do Campo 06 (VL_BC_COFINS_NC); 
+            ///     - Para os CST_COFINS = "53", "54", "55", "56", "63", "64" "65" e "66" 
+            ///       (Crédito sobre operações vinculadas a mais de um tipo de receita): 
+            ///       Informar a parcela do valor do Campo 06 (VL_BC_COFINS_NC) vinculada especificamente ao tipo 
+            ///       de crédito escriturado em M500. 
+            ///
+            ///       O valor deste campo será transportado para o Campo 04 (VL_BC_COFINS) do registro M500.
+            /// </summary>
+            [SpedCampos(7, "VL_BC_COFINS", "N", 0, 2, false)]
+            public decimal? VlBcCofins { get; set; }
+
+            /// <summary>
+            ///     Quantidade Total da Base de Cálculo do Crédito apurado em Unidade de Medida de Produto, 
+            ///     escriturada nos documentos e operações (Blocos "A", "C", "D" e "F"), 
+            ///     referente ao CST_COFINS informado no Campo 03 
+            /// </summary>
+            [SpedCampos(8, "QUANT_BC_COFINS_TOT", "N", 0, 3, false)]
+            public decimal? QuantBcCofinsTot { get; set; }
+
+            /// <summary>
+            ///     Parcela da base de cálculo do crédito em quantidade (campo 08) 
+            ///     vinculada ao tipo de crédito escriturado em M500. 
+            ///     - Para os CST_COFINS = "50", “51" e "52": Informar o valor do Campo 08 (QUANT_BC_COFINS); 
+            ///     - Para os CST_COFINS = "53", “54", "55" e "56" (crédito vinculado a mais de um tipo de receita): 
+            ///     Informar a parcela do valor do Campo 08 (QUANT_BC_COFINS) vinculada 
+            ///     ao tipo de crédito escriturado em M500. 
+            ///
+            ///O valor deste campo será transportado para o Campo 06 (QUANT_BC_COFINS) do registro M500.
+            /// </summary>
+            [SpedCampos(9, "QUANT_BC_COFINS", "N", 0, 3, false)]
+            public decimal? QuantBcCofins { get; set; }
+
+            /// <summary>
+            ///     Descrição do crédito
+            /// </summary>
+            [SpedCampos(10, "DESC_CRED", "C", 60, 0, false)]
+            public string DescCred { get; set; }
+        }
+
+        /// <summary>
+        ///     REGISTRO M600: CONSOLIDAÇÃO DA CONTRIBUIÇÃO PARA A SEGURIDADE SOCIAL - COFINS DO PERIODO
+        /// </summary>
         public class RegistroM600 : RegistroBaseSped
         {
             public RegistroM600()
@@ -668,7 +868,7 @@ namespace SpedBr.EfdContribuicoes
             ///     sem contribuição apurada a pagar, conforme a Tabela 4.3.3.
             /// </summary>
             [SpedCampos(2, "CST_COFINS", "C", 2, 0, true)]
-            public int CstCofins { get; set; }
+            public string CstCofins { get; set; }
 
             /// <summary>
             ///     Valor total da receita bruta no período. 


### PR DESCRIPTION
Inserção dos registros 0500 e 0600 do Sped-Contribuições, já atualizados os tamanhos dos campos Cod_Cta, Cod_Cta_Ref e Cod_Ccus conforme o manual de 04/10/2017.